### PR TITLE
[bug] Fix speed up patch file on service worker

### DIFF
--- a/build_tools/web/flutter_service_worker.js.patch
+++ b/build_tools/web/flutter_service_worker.js.patch
@@ -26,6 +26,7 @@ see: https://github.com/dwyl/app/issues/326#issuecomment-1478314967
 +// Removed this section because the files are downloaded concurrently, so we don't check
 +
 +
++var IN_PROCESSING_REQUESTS = {};
  // During activate, the cache is populated with the temp files downloaded in
  // install. If this service worker is upgrading from one with a saved
  // MANIFEST, then use this to retain unchanged resource files.

--- a/build_tools/web/flutter_service_worker.js.patch
+++ b/build_tools/web/flutter_service_worker.js.patch
@@ -27,6 +27,7 @@ see: https://github.com/dwyl/app/issues/326#issuecomment-1478314967
 +
 +
 +var IN_PROCESSING_REQUESTS = {};
++
  // During activate, the cache is populated with the temp files downloaded in
  // install. If this service worker is upgrading from one with a saved
  // MANIFEST, then use this to retain unchanged resource files.


### PR DESCRIPTION
related to https://github.com/dwyl/app/issues/333

Checking the file *after* the patch, it seems that a variable wasn't correctly initialized.
This should fix the issue facing in #333.

If correctly merged, we should do the same in the `dwyl/learn-flutter` repo as well.